### PR TITLE
fix: add strapi url to swagger

### DIFF
--- a/plugins/documentation/config/settings.json
+++ b/plugins/documentation/config/settings.json
@@ -25,7 +25,7 @@
       "description": "Development server"
     },
     {
-      "url": "YOUR_STAGING_SERVER",
+      "url": "https://strapi-perfect-week.herokuapp.com/",
       "description": "Staging server server"
     },
     {


### PR DESCRIPTION
- Swagger was not showing the proper staging URL