### PR TITLE
feat: add dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+plugins/**/node_modules
+admin/node_modules
+.git
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:lts
+
+RUN apt-get update && apt-get install -y libgl1-mesa-glx && apt-get clean
+
+WORKDIR /usr/app/api
+COPY ./ ./
+
+RUN npm install \
+&& npm run postinstall \
+&& rm -rf ./node_modules/websocket/.git \
+&& npm run setup --plugins --debug
+
+CMD ["npm", "start"]

--- a/config/environments/production/database.json
+++ b/config/environments/production/database.json
@@ -9,8 +9,7 @@
         "port": "${process.env.DATABASE_PORT || 27017}",
         "database": "${process.env.DATABASE_NAME || 'strapi'}",
         "username": "${process.env.DATABASE_USERNAME || ''}",
-        "password": "${process.env.DATABASE_PASSWORD || ''}",
-        "ssl": true
+        "password": "${process.env.DATABASE_PASSWORD || ''}"
       },
       "options": {}
     }


### PR DESCRIPTION
- Add docker image to be used as pod inside production kubernetes cluster
- Remove `ssl: true` value in production database configuration (database is only accessible inside of cluster and ssl is only overhead)